### PR TITLE
Fix Heimdallr.getAccessBinary is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ class Heimdallr {
               }
 
               const names = Config.IAM.roles
-              const binary = Heimdallr.getAccessBinary(moduleAccess)
+              const binary = Heimdallr.accessBinary(moduleAccess)
               const binaries = binary.split('')
 
               for (let i in names) {

--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ class Heimdallr {
         }
 
         for (let _IAM of rawIAM) {
-          const appId = _IAM.app_id
+          const appId = _IAM.project_id
           let access
 
           try {


### PR DESCRIPTION
Error when used role user with access defined.